### PR TITLE
CLD-6156 [feat] CI Convert to using GhAPP for CI token

### DIFF
--- a/.github/workflows/issue_add.yml
+++ b/.github/workflows/issue_add.yml
@@ -13,7 +13,13 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: mattermost/github-app-installation-token-action@181cd1b8c94b158428c4facfe043d6e28c20be55
+        id: ghapp
+        with:
+          appId: "${{ vars.UNIFIED_CI_APP_ID }}"
+          installationId: "${{ vars.UNIFIED_CI_INSTALLATION_ID }}"
+          privateKey: ${{ secrets.UNIFIED_CI_PRIVATE_KEY }}
+      - uses: actions/add-to-project@31b3f3ccdc584546fc445612dec3f38ff5edb41c #v0.5.0
         with:
           project-url: https://github.com/orgs/mattermost/projects/9
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.ghapp.outputs.token }}


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Converting to using Unified CI GitHub App, for the needs of CI. 
- Pinning Github Apps reference used, for security 


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/CLD-6156
