### PR TITLE
Avoid running add-to-project job on forks

### DIFF
--- a/.github/workflows/issue_add.yml
+++ b/.github/workflows/issue_add.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   add-to-project:
+    if: ${{ github.repository_owner == 'mattermost' }}
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Since the workflow to automatically add an issue to our plugin maintenance board is only for internal use, we should avoid running this on forked repositories. This PR makes it so the `add-to-project` job only runs on repos owned by the `mattermost` org.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

